### PR TITLE
Pedantic physics bugfixes

### DIFF
--- a/Src/Objects/Player.tscn
+++ b/Src/Objects/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=2]
+[gd_scene load_steps=24 format=2]
 
 [ext_resource path="res://Assets/Sprites/Player/Idle.png" type="Texture" id=1]
 [ext_resource path="res://Assets/Sprites/Player/Fall.png" type="Texture" id=2]
@@ -9,28 +9,28 @@
 [ext_resource path="res://Assets/Sounds/Jump.wav" type="AudioStream" id=7]
 
 [sub_resource type="AtlasTexture" id=1]
-atlas = ExtResource( 1 )
+atlas = ExtResource( 2 )
 region = Rect2( 0, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=2]
-atlas = ExtResource( 1 )
+atlas = ExtResource( 2 )
 region = Rect2( 32, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=3]
 atlas = ExtResource( 1 )
-region = Rect2( 64, 0, 32, 32 )
+region = Rect2( 32, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=4]
 atlas = ExtResource( 1 )
-region = Rect2( 96, 0, 32, 32 )
-
-[sub_resource type="AtlasTexture" id=5]
-atlas = ExtResource( 4 )
 region = Rect2( 0, 0, 32, 32 )
 
+[sub_resource type="AtlasTexture" id=5]
+atlas = ExtResource( 1 )
+region = Rect2( 64, 0, 32, 32 )
+
 [sub_resource type="AtlasTexture" id=6]
-atlas = ExtResource( 4 )
-region = Rect2( 32, 0, 32, 32 )
+atlas = ExtResource( 1 )
+region = Rect2( 96, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=7]
 atlas = ExtResource( 5 )
@@ -53,23 +53,23 @@ atlas = ExtResource( 5 )
 region = Rect2( 128, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=12]
-atlas = ExtResource( 2 )
+atlas = ExtResource( 4 )
 region = Rect2( 0, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=13]
-atlas = ExtResource( 2 )
+atlas = ExtResource( 4 )
 region = Rect2( 32, 0, 32, 32 )
 
 [sub_resource type="SpriteFrames" id=14]
 animations = [ {
-"frames": [ SubResource( 1 ), SubResource( 2 ), SubResource( 3 ), SubResource( 4 ) ],
+"frames": [ SubResource( 1 ), SubResource( 2 ) ],
 "loop": true,
-"name": "Idle",
+"name": "Fall",
 "speed": 10.0
 }, {
-"frames": [ SubResource( 5 ), SubResource( 6 ) ],
+"frames": [ SubResource( 3 ), SubResource( 4 ), SubResource( 5 ), SubResource( 6 ) ],
 "loop": true,
-"name": "Jump",
+"name": "Idle",
 "speed": 10.0
 }, {
 "frames": [ SubResource( 7 ), SubResource( 8 ), SubResource( 9 ), SubResource( 10 ), SubResource( 11 ) ],
@@ -79,32 +79,38 @@ animations = [ {
 }, {
 "frames": [ SubResource( 12 ), SubResource( 13 ) ],
 "loop": true,
-"name": "Fall",
+"name": "Jump",
 "speed": 10.0
 } ]
 
 [sub_resource type="RectangleShape2D" id=15]
-extents = Vector2( 5.49494, 10.0077 )
+extents = Vector2( 5.5, 10.5 )
 
-[node name="Player" type="KinematicBody2D"]
+[sub_resource type="CanvasItemMaterial" id=16]
+blend_mode = 1
+
+[node name="Player" type="KinematicBody2D" groups=[
+"Player",
+]]
 z_index = 10
 script = ExtResource( 3 )
 
 [node name="Sprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 14 )
-animation = "Jump"
+animation = "Idle"
+frame = 3
 playing = true
 offset = Vector2( 0, -6 )
-__meta__ = {
-"_edit_lock_": true
-}
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2( 0.5, 0 )
+[node name="Hull" type="CollisionShape2D" parent="."]
+position = Vector2( 2.5, -0.5 )
 shape = SubResource( 15 )
-__meta__ = {
-"_edit_lock_": true
-}
+
+[node name="Visualizer" type="Polygon2D" parent="Hull"]
+visible = false
+modulate = Color( 0.0463562, 0.209327, 0.382813, 1 )
+material = SubResource( 16 )
+polygon = PoolVector2Array( 5.5, -10.5, 5.5, 10.5, -5.5, 10.5, -5.5, -10.5 )
 
 [node name="JumpSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 7 )
@@ -113,11 +119,12 @@ stream = ExtResource( 7 )
 stream = ExtResource( 6 )
 
 [node name="SpikeCollision" type="Area2D" parent="."]
+visible = false
+position = Vector2( 2, -0.5 )
 collision_layer = 2
 collision_mask = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="SpikeCollision"]
-visible = false
 position = Vector2( 0.5, 0 )
 shape = SubResource( 15 )
 __meta__ = {
@@ -125,16 +132,20 @@ __meta__ = {
 }
 
 [node name="PlatformCollision" type="Area2D" parent="."]
+visible = false
+position = Vector2( 2, -0.5 )
 collision_layer = 4
 collision_mask = 4
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="PlatformCollision"]
-visible = false
 position = Vector2( 0.5, 0 )
 shape = SubResource( 15 )
 __meta__ = {
 "_edit_lock_": true
 }
+
+[node name="Camera2D" type="Camera2D" parent="."]
+zoom = Vector2( 0.25, 0.25 )
 
 [connection signal="body_entered" from="SpikeCollision" to="." method="_on_SpikeCollision_body_entered"]
 [connection signal="body_entered" from="PlatformCollision" to="." method="_on_PlatformCollision_body_entered"]

--- a/Src/Scripts/Bullet.gd
+++ b/Src/Scripts/Bullet.gd
@@ -14,7 +14,9 @@ func _physics_process(delta):
 	position.x += speed * delta
 
 
+var parent : Node = null
 func _on_Bullet_body_entered(body):
 	if not body.name == "Player":
-		get_parent().get_node("Player").bullets -= 1
-		get_parent().remove_child(self)
+		if is_instance_valid(parent):
+			parent.bullets -= 1
+			get_parent().remove_child(self)

--- a/Src/Scripts/Player.gd
+++ b/Src/Scripts/Player.gd
@@ -1,12 +1,13 @@
 extends KinematicBody2D
 
-var h_speed = 150
+var h_speed = 3
 var direction = 1
 
-var MAX_FALL_SPEED = 400
-var gravity = 1100
-var jump_force = -415
-var double_jump_force = -363
+var MAX_FALL_SPEED = 9
+var gravity = 0.4
+var jump_force = -8.5
+var double_jump_force = -7
+var jump_release_limit = 0.45
 
 var jumping = true
 var double_jump = true
@@ -23,11 +24,13 @@ onready var jump_sound = $JumpSound
 onready var d_jump_sound = $DoubleJumpSound
 onready var death_sound = $DeathSound
 
-func _physics_process(delta):
-	velocity.y += gravity * delta
+func _process(_delta):
+	get_input()
+	
+	velocity.y += gravity
 	if velocity.y > MAX_FALL_SPEED:
 		velocity.y = MAX_FALL_SPEED
-	get_input()
+	
 	if is_on_floor():
 		if not velocity.x == 0:
 			sprite.animation = "Run"
@@ -38,31 +41,49 @@ func _physics_process(delta):
 			sprite.animation = "Jump"
 		else:
 			sprite.animation = "Fall"
-	move_and_slide(velocity,Vector2(0,-1))
+	
+	# FIXME: move the entire movement solver to repeated move_and_collide calls instead of using move_and_slide
+	move_and_slide(velocity/_delta,Vector2(0,-1))
 	
 	if is_on_floor():
 		velocity.y = 0
 		jumping = false
 		double_jump = true
 	else:
-		 jumping = true
+		jumping = true
 	
 	if is_on_ceiling():
 		velocity.y = 0
+
+var frames_moving = 0
 
 func get_input():
 	velocity.x = 0
 	
 	if Input.is_action_pressed("right"):
-		velocity.x += h_speed
+		if frames_moving > 0:
+			velocity.x += h_speed
 		if direction == -1:
+			$Sprite.position.x += 1
+			$Hull.position.x += 2
+			#position.x -= 1
 			direction = 1
 			scale.x = -1
+			#$Hull.position.x = 2.5
+		frames_moving += 1
 	elif Input.is_action_pressed("left"):
-		velocity.x -= h_speed
+		if frames_moving > 0:
+			velocity.x -= h_speed
 		if direction == 1:
+			$Sprite.position.x -= 1
+			$Hull.position.x -= 2
+			#position.x += 1
 			direction = -1
 			scale.x = -1
+			#$Hull.position.x = 1.5
+		frames_moving += 1
+	else:
+		frames_moving = 0
 	
 	if Input.is_action_just_pressed("jump"):
 		if jumping and double_jump and not platform:
@@ -75,12 +96,13 @@ func get_input():
 			double_jump = true
 			jump_sound.play()
 	
-	if Input.is_action_just_released("jump") and velocity.y < -130:
-		velocity.y = -130
+	if Input.is_action_just_released("jump") and velocity.y < 0:
+		velocity.y = velocity.y*0.45
 	
 	if Input.is_action_just_pressed("shoot"):
 		if bullets < max_bullets:
 			var new_bullet = bullet.instance()
+			new_bullet.parent = self
 			new_bullet.position = position
 			get_parent().add_child(new_bullet)
 			bullets += 1

--- a/Src/Scripts/Save.gd
+++ b/Src/Scripts/Save.gd
@@ -5,10 +5,12 @@ onready var animation_timer = $AnimationTimer
 
 
 func _on_Save_area_entered(area):
-	animation.frame = 1
-	Global.save_position = get_parent().get_node("Player").global_position
-	Global.save()
-	animation_timer.start()
+	var player = get_parent().get_node("Player")
+	if is_instance_valid(player):
+		animation.frame = 1
+		Global.save_position = get_parent().get_node("Player").global_position
+		Global.save()
+		animation_timer.start()
 
 
 func _on_AnimationTimer_timeout():

--- a/project.godot
+++ b/project.godot
@@ -23,10 +23,15 @@ Global="*res://Global.gd"
 Music="*res://BGM.tscn"
 DeathScreen="*res://Src/Scenes/DeathScreen.tscn"
 
+[debug]
+
+settings/fps/force_fps=50
+
 [display]
 
 window/size/width=800
 window/size/height=608
+window/vsync/use_vsync=false
 window/stretch/mode="2d"
 window/stretch/aspect="keep"
 


### PR DESCRIPTION
- disable vsync and use the software framerate limiter to run at a fixed 50fps, to avoid microstuttering and compatibility issues with high-refresh-rate monitors
- use _process instead of _physics_process to avoid judder when the rendering framerate falls out of sync with the physics subsystem
- don't use delta time because it's evil for precision platformers
-- this also makes it easier to compare movement code with standard engines. if you want to implement fixed timestep interpolation later you can do it on top of this approach instead of using delta time
-- this also makes it okay to use _process instead of _physics_process, despite being against best practices
-- wanting to do this is another reason why it's important to use the software framerate limiter instead of vsync, otherwise things would run faster on high-refresh-rate monitors
- gravity and input were being done in the wrong order, making jump height wrong; swap them
- the behavior when releasing the jump key mid-jump was nonstandard, fixed
- fix player's collision box being the wrong size (one pixel too short)
- align the player's sprite and collision box the standard way, pixel-precise, even when looking left
- the first frame of left/right input is not supposed to actually move the player, fixed
- fixed some crashes involving trying to get the player when they're dead

(yes, the collision hull really is supposed to be aligned in this weird of a way, see image:)
![image](https://user-images.githubusercontent.com/585488/129011441-d97b20b4-6e4a-47d6-b80c-e36985bcafdc.png)

disabling vsync and using godot's software framerate limiter might, in theory, cause problems for operating systems with vsync'd compositors and low update rate displays, so don't merge this blindly, test it first (my setup doesn't have a vsync'd compositor)

I have no idea why the animation stuff got reordered in the project files but it doesn't seem to have changed anything, also you should probably move to an AnimationPlayer in the future for better flexibility.